### PR TITLE
Promotion expires when total usage count is equal to total usage limit

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^1.17.0",
+    "@commercelayer/app-elements": "^1.17.1",
     "@commercelayer/sdk": "5.33.1",
     "@hookform/resolvers": "^3.3.4",
     "lodash": "^4.17.21",

--- a/packages/app/src/pages/PromotionDetailsPage.tsx
+++ b/packages/app/src/pages/PromotionDetailsPage.tsx
@@ -92,8 +92,7 @@ function Page(
 
           {createdFromApi && (
             <Alert status='info'>
-              This API-generated promotion can only be enabled or disabled. The
-              customization options are not available.
+              This API-generated promotion can only be enabled or disabled.
             </Alert>
           )}
 
@@ -172,6 +171,9 @@ const CardStatus = withSkeletonTemplate<{
 
     let statusDescription = ''
     switch (displayStatus.status) {
+      case 'used':
+        statusDescription = 'Usage limit exceeded'
+        break
       case 'disabled':
         if (promotion.disabled_at != null) {
           statusDescription = formatDateWithPredicate({

--- a/packages/app/src/pages/PromotionListPage.tsx
+++ b/packages/app/src/pages/PromotionListPage.tsx
@@ -67,7 +67,9 @@ function Page(props: PageProps<typeof appRoutes.promotionList>): JSX.Element {
                 'name',
                 'coupons',
                 'reference_origin',
-                'disabled_at'
+                'disabled_at',
+                'total_usage_limit',
+                'total_usage_count'
               ]
             },
             include: ['coupons'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   packages/app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^1.17.0
-        version: 1.17.0(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1)
+        specifier: ^1.17.1
+        version: 1.17.1(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1)
       '@commercelayer/sdk':
         specifier: 5.33.1
         version: 5.33.1
@@ -355,8 +355,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.17.0(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1):
-    resolution: {integrity: sha512-DJmETCUh8TWF5TlZnrJDKbo+8+jBf9XevfPcK5SzTUsO6NV9u4dGcivbSWuYZxatxWYj6eGxjD3ueCG7oDdBwg==}
+  /@commercelayer/app-elements@1.17.1(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1):
+    resolution: {integrity: sha512-x69KQWSzskCe9jANQF4SQlsL+RuzA/s17G84Tvaw9Dk3CWzg5lHMbawYWIi2z1bvzSI1Lvi6nQg4T9wrWBHiWg==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
## What I did

I update elements to the latest to manage the promotion expiration when total usage count is equal to total usage limit.

In this scenario, I show a dedicated text in the promotion detail page.

https://github.com/commercelayer/app-promotions/assets/1681269/e75355ce-c7a4-4339-b29d-def822923521

