### PR TITLE
Add `order_tags` activation rule

### DIFF
--- a/packages/app/src/data/ruleBuilder/config.tsx
+++ b/packages/app/src/data/ruleBuilder/config.tsx
@@ -126,6 +126,16 @@ export const ruleBuilderConfig: RuleBuilderConfig = {
       return true
     }
   },
+  order_tags_id: {
+    resource: 'custom_promotion_rules',
+    rel: 'tags',
+    label: 'Order tag',
+    operators: [matchers.in, matchers.not_in],
+    Component: () => <SelectTagComponent />,
+    isAvailable() {
+      return true
+    }
+  },
   subtotal_amount_cents: {
     resource: 'custom_promotion_rules',
     rel: null,
@@ -158,6 +168,7 @@ export type RuleBuilderConfig = Record<
   | 'total_amount_cents'
   | 'line_items_sku_tags_id'
   | 'customer_tags_id'
+  | 'order_tags_id'
   | 'subtotal_amount_cents'
   | 'skuListPromotionRule',
   {


### PR DESCRIPTION
Closes commercelayer/issues-app#63

## What I did

I added the "order tag" activation rule.

<img width="659" alt="Screenshot 2024-04-22 alle 10 36 56" src="https://github.com/commercelayer/app-promotions/assets/1681269/fad133dc-8111-4666-9a1b-c665155fbdc5">
