### PR TITLE
Add "custom email ends with" activation rule

### DIFF
--- a/packages/app/src/data/ruleBuilder/config.tsx
+++ b/packages/app/src/data/ruleBuilder/config.tsx
@@ -35,9 +35,13 @@ export const matchers = {
   gt: {
     label: 'is greater than',
     value: 'gt'
+  },
+  end_any: {
+    label: 'ends with',
+    value: 'end_any'
   }
 } as const satisfies {
-  [key in 'in' | 'not_in' | 'eq' | 'gteq' | 'gt']: {
+  [key in 'in' | 'not_in' | 'eq' | 'gteq' | 'gt' | 'end_any']: {
     label: string
     value: key
   }
@@ -126,6 +130,16 @@ export const ruleBuilderConfig: RuleBuilderConfig = {
       return true
     }
   },
+  customer_email: {
+    resource: 'custom_promotion_rules',
+    rel: null,
+    label: 'Customer email',
+    operators: [matchers.end_any],
+    Component: () => <HookedInput name='value' />,
+    isAvailable() {
+      return true
+    }
+  },
   order_tags_id: {
     resource: 'custom_promotion_rules',
     rel: 'tags',
@@ -168,6 +182,7 @@ export type RuleBuilderConfig = Record<
   | 'total_amount_cents'
   | 'line_items_sku_tags_id'
   | 'customer_tags_id'
+  | 'customer_email'
   | 'order_tags_id'
   | 'subtotal_amount_cents'
   | 'skuListPromotionRule',


### PR DESCRIPTION
Closes commercelayer/issues-app#71

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added the new activation rule: "custom email ends with".

<img width="653" alt="create 'custom email ends with' overlay" src="https://github.com/commercelayer/app-promotions/assets/1681269/f269c55b-3af9-4de8-9800-7baae76daa37">

<img width="672" alt="apply when 'custom email ends with'" src="https://github.com/commercelayer/app-promotions/assets/1681269/10129e71-50dd-4a63-b439-8ea58557637e">
