### PR TITLE
Add promotions `reference`

### DIFF
--- a/packages/app/src/components/PromotionForm.tsx
+++ b/packages/app/src/components/PromotionForm.tsx
@@ -125,6 +125,10 @@ export function PromotionForm({
               }}
             />
           </Spacer>
+
+          <Spacer top='6'>
+            <HookedInput name='reference' label='Reference' />
+          </Spacer>
         </Section>
       </Spacer>
 

--- a/packages/app/src/data/formConverters/promotion.ts
+++ b/packages/app/src/data/formConverters/promotion.ts
@@ -14,7 +14,11 @@ export function promotionToFormValues(promotion?: Promotion) {
     expires_at: new Date(promotion.expires_at),
     apply_the_discount_to: promotion.sku_list != null ? 'sku_list' : 'all',
     show_priority: promotion.priority != null,
-    sku_list: promotion.sku_list?.id
+    sku_list: promotion.sku_list?.id,
+    reference:
+      promotion.reference != null && promotion.reference !== ''
+        ? promotion.reference
+        : null
   }
 }
 
@@ -33,6 +37,12 @@ export function formValuesToPromotion(
     total_usage_limit:
       'total_usage_limit' in formValues && formValues.total_usage_limit != null
         ? formValues.total_usage_limit
+        : null,
+    reference:
+      'reference' in formValues &&
+      formValues.reference != null &&
+      formValues.reference !== ''
+        ? formValues.reference
         : null,
     priority:
       'priority' in formValues && formValues.priority != null

--- a/packages/app/src/data/promotions/configs/promotions.tsx
+++ b/packages/app/src/data/promotions/configs/promotions.tsx
@@ -4,6 +4,7 @@ export const genericPromotionOptions = z.object({
   name: z.string().min(1),
   starts_at: z.date(),
   expires_at: z.date(),
+  reference: z.string().nullish(),
   total_usage_limit: z
     .number()
     .min(1)

--- a/packages/app/src/pages/PromotionDetailsPage.tsx
+++ b/packages/app/src/pages/PromotionDetailsPage.tsx
@@ -365,6 +365,11 @@ const SectionInfo = withSkeletonTemplate<{
           {promotion.priority}
         </ListDetailsItem>
       )}
+      {promotion.reference != null && promotion.reference !== '' && (
+        <ListDetailsItem label='Reference' gutter='none'>
+          {promotion.reference}
+        </ListDetailsItem>
+      )}
     </Section>
   )
 })


### PR DESCRIPTION
closes commercelayer/issues-app#98

## What I did

I added the promotion `reference` as editable field.

## How to test



https://github.com/commercelayer/app-promotions/assets/1681269/ef8d3b45-fe3c-48b2-99e9-d7520ec5eeee

